### PR TITLE
New `decode_setting` & improved `django_settings_env_capture`

### DIFF
--- a/devautotools/__init__.py
+++ b/devautotools/__init__.py
@@ -9,4 +9,4 @@ from ._env import env_vars_from_ini, env_vars_from_json, env_with_vars_from_ini,
 from ._venv import deploy_local_venv
 from ._venvctrl import VirtualEnvironmentManager
 
-__version__ = '1.2.0.dev1'
+__version__ = '1.2.0.dev2'

--- a/devautotools/__init__.py
+++ b/devautotools/__init__.py
@@ -9,4 +9,4 @@ from ._env import env_vars_from_ini, env_vars_from_json, env_with_vars_from_ini,
 from ._venv import deploy_local_venv
 from ._venvctrl import VirtualEnvironmentManager
 
-__version__ = '1.2.0.dev3'
+__version__ = '1.2.0'

--- a/devautotools/__init__.py
+++ b/devautotools/__init__.py
@@ -3,10 +3,10 @@
 Several tools to automate development related tasks.
 """
 
-from ._django import deploy_local_django_site, django_normalized_settings, django_settings_env_capture, normalize_variable_name, normalized_settings, path_for_setting, setting_is_true, DjangoLinkedSite
+from ._django import decode_setting, deploy_local_django_site, django_normalized_settings, django_settings_env_capture, normalize_variable_name, normalized_settings, path_for_setting, setting_is_true, DjangoLinkedSite
 from ._docker import start_local_docker_container, stop_local_docker_container
 from ._env import env_vars_from_ini, env_vars_from_json, EnvironmentalPipes
 from ._venv import deploy_local_venv
 from ._venvctrl import VirtualEnvironmentManager
 
-__version__ = '1.1.0'
+__version__ = '1.2.0.dev0'

--- a/devautotools/__init__.py
+++ b/devautotools/__init__.py
@@ -9,4 +9,4 @@ from ._env import env_vars_from_ini, env_vars_from_json, env_with_vars_from_ini,
 from ._venv import deploy_local_venv
 from ._venvctrl import VirtualEnvironmentManager
 
-__version__ = '1.2.0.dev2'
+__version__ = '1.2.0.dev3'

--- a/devautotools/__init__.py
+++ b/devautotools/__init__.py
@@ -5,8 +5,8 @@ Several tools to automate development related tasks.
 
 from ._django import decode_setting, deploy_local_django_site, django_normalized_settings, django_settings_env_capture, normalize_variable_name, normalized_settings, path_for_setting, setting_is_true, DjangoLinkedSite
 from ._docker import start_local_docker_container, stop_local_docker_container
-from ._env import env_vars_from_ini, env_vars_from_json, EnvironmentalPipes
+from ._env import env_vars_from_ini, env_vars_from_json, env_with_vars_from_ini, env_with_vars_from_json, EnvironmentalPipes
 from ._venv import deploy_local_venv
 from ._venvctrl import VirtualEnvironmentManager
 
-__version__ = '1.2.0.dev0'
+__version__ = '1.2.0.dev1'

--- a/devautotools/_django.py
+++ b/devautotools/_django.py
@@ -25,6 +25,45 @@ REQUIRED_SECTION_RE = re_compile(r'(:?.+_required)|(:?required_.+)', RE_IGNORECA
 TRUTH_LOWERCASE_STRING_VALUES = ('true', 'yes', 'on', '1')
 
 
+def _decode_setting(django_settings, base_var_name, lowercase=False):
+	"""Decode a setting
+	Given an environment variable name, find the correct value for the corresponding setting. The setting name would be the base name. The logic is:
+	1. if the base_var_name is found, it's returned as is and the "decoded" flag is False
+	2. if base_var_name + "_CONTENT" is found (ex: FOO_CONTENT) then the content is returned as is.
+	3. if base_var_name + "_BASE64" is found (ex: FOO_BASE64) then the content of the variable is base64 decoded before returning it.
+	In every case but #1 the "decoded" flag will be True, meaning that you can use it to identify if this function found the "base_var_name" or a variation of it.
+	If you're not interested on the decoding flag and want the decoded value unconditionally, use the "decode_setting" instead.
+
+	:param django_settings: the global variables from the original settings.py file
+	:type django_settings: dict
+	:param base_var_name: the name of the environment variable to look for
+	:type base_var_name: str
+	:param lowercase: if the variations suffixes should be lowercase
+	:type lowercase: bool
+	:return: A tuple of length 2, with the "decoded" flag first and the decoded content of the variable on the 2nd.
+	:rtype: tuple
+	"""
+	
+	env_var_variations = {
+		'CONTENT': base_var_name + ('_content' if lowercase else '_CONTENT'),
+		'BASE64': base_var_name + ('_base64' if lowercase else '_BASE64'),
+	}
+	
+	decoded, content = True, None
+	if base_var_name in django_settings['ENVIRONMENTAL_SETTINGS_KEYS']:
+		decoded, content = False, django_settings['ENVIRONMENTAL_SETTINGS'][base_var_name]
+	elif env_var_variations['CONTENT'] in django_settings['ENVIRONMENTAL_SETTINGS_KEYS']:
+		content = django_settings['ENVIRONMENTAL_SETTINGS'][env_var_variations['CONTENT']]
+	elif env_var_variations['BASE64'] in django_settings['ENVIRONMENTAL_SETTINGS_KEYS']:
+		content = b64decode(django_settings['ENVIRONMENTAL_SETTINGS'][env_var_variations['BASE64']])
+	else:
+		decoded = False
+	
+	return decoded, content
+
+decode_setting = lambda django_settings, base_var_name, lowercase=False: _decode_setting(django_settings=django_settings, base_var_name=base_var_name, lowercase=lowercase)[1]
+
+
 def deploy_local_django_site(*secret_json_files_paths, dev_from_pypi=False, venv_options={}, pip_install_options={}, django_site_name='test_site', extra_paths_to_link='', create_cache_table=False, superuser_password='', just_build=False):
 	"""Deploy a local Django site
 	Starts by deploying a new virtual environment via "deploy_local_env()" and then creates a test site with symlinks to the existing project files. It runs the test server until it gets stopped (usually with ctrl + c).
@@ -280,11 +319,7 @@ def normalized_settings(**django_settings):
 
 def path_for_setting(django_settings, base_var_name, lowercase=False):
 	"""Path for a setting
-	Given an environment variable name, find the correct value for the corresponding setting. The setting name would be the base name. The logic is:
-	1. if the base_var_name is found, it's returned as is. This is usually the case when the file is managed outside and the path is provided to Django.
-	2. if base_var_name + "_CONTENT" is found (ex: FOO_CONTENT) then the content of the variable is written to a temporary file and the path to such file is returned.
-	3. if base_var_name + "_BASE64" is found (ex: FOO_BASE64) then the content of the variable is base64 decoded, then written to a temporary file, and the path to such file is returned. You can provide binary content using this method but keep in mind the buffer limits of your operating system.
-	The file is created using "mkstemp" and any related limitations and security considerations apply. The file is automatically removed when the Python interpreter ends (atexit + os.remove).
+	Given an environment variable name, decode the content if applicable, write it into a temporary file and return the path to such file. The "decoding" logic is implemented on the "_decode_setting" function. The file is created using "mkstemp" and any related limitations and security considerations apply. The file is automatically removed when the Python interpreter ends (atexit + os.remove).
 
 	:param django_settings: the global variables from the original settings.py file
 	:type django_settings: dict
@@ -295,24 +330,16 @@ def path_for_setting(django_settings, base_var_name, lowercase=False):
 	:return: The path for the setting
 	:rtype: any
 	"""
-
-	env_var_variations = {
-		'CONTENT': base_var_name + ('_content' if lowercase else '_CONTENT'),
-		'BASE64': base_var_name + ('_base64' if lowercase else '_BASE64'),
-	}
-
-	if base_var_name in django_settings['ENVIRONMENTAL_SETTINGS_KEYS']:
-		return django_settings['ENVIRONMENTAL_SETTINGS'][base_var_name]
-	elif env_var_variations['CONTENT'] in django_settings['ENVIRONMENTAL_SETTINGS_KEYS']:
-		extra_mode, file_content = 't', django_settings['ENVIRONMENTAL_SETTINGS'][env_var_variations['CONTENT']]
-	elif env_var_variations['BASE64'] in django_settings['ENVIRONMENTAL_SETTINGS_KEYS']:
-		extra_mode, file_content = 'b', b64decode(django_settings['ENVIRONMENTAL_SETTINGS'][env_var_variations['BASE64']])
-	else:
-		return None
+	
+	decoded, content = _decode_setting(django_settings=django_settings, base_var_name=base_var_name, lowercase=lowercase)
+	if not decoded:
+		return content
+	
+	extra_mode = 't' if isinstance(content, str) else 'b'
 	
 	file_desc, file_path = mkstemp(text=True, session=True)
-	with open(file_path, 'w'+extra_mode) as file_obj:
-		file_obj.write(file_content)
+	with open(file_path, f'w{extra_mode}') as file_obj:
+		file_obj.write(content)
 
 	return file_path
 

--- a/devautotools/_django.py
+++ b/devautotools/_django.py
@@ -8,7 +8,7 @@ from email.utils import getaddresses as parse_email_addresses
 from importlib import import_module
 from json import loads as json_loads
 from logging import getLogger
-from os import environ, getenv
+from os import environ, getenv, name as os_name
 from pathlib import Path
 from re import compile as re_compile, search as re_search, IGNORECASE as RE_IGNORECASE
 from shutil import rmtree
@@ -496,7 +496,9 @@ class DjangoLinkedSite:
 		site.venv.install('devautotools', **pip_install_options)
 		site.create(project_paths_to_site=extra_paths_to_link)
 		superuser = site.initialize(environment_content=environment_content, create_cache_table=create_cache_table, superuser_password=superuser_password)
-
+		
+		env_django_debug = ['$env:DJANGO_DEBUG=true;'] if os_name == 'nt' else ['env DJANGO_DEBUG=true']
+		
 		if secret_json_files_paths:
 			inline_vars = ['`./venv/bin/python -m devautotools env_vars_from_json --uppercase_vars {secret_files}`'.format(secret_files=' '.join([str(s) for s in secret_json_files_paths]))]
 		else:
@@ -507,7 +509,7 @@ class DjangoLinkedSite:
 			'',
 			'You can run this again with:',
 			'',
-			' '.join(['env DJANGO_DEBUG=true'] + inline_vars + ['./venv/bin/python ./test_site/manage.py runserver --settings=test_site.local_settings']),
+			' '.join(env_django_debug + inline_vars + ['./venv/bin/python ./test_site/manage.py runserver --settings=test_site.local_settings']),
 			'',
 		]
 

--- a/devautotools/_django.py
+++ b/devautotools/_django.py
@@ -500,7 +500,8 @@ class DjangoLinkedSite:
 		env_django_debug = ['$env:DJANGO_DEBUG=true;'] if os_name == 'nt' else ['env DJANGO_DEBUG=true']
 		
 		if secret_json_files_paths:
-			inline_vars = ['`./venv/bin/python -m devautotools env_vars_from_json --uppercase_vars {secret_files}`'.format(secret_files=' '.join([str(s) for s in secret_json_files_paths]))]
+			env_python_path = '.\\venv\\Scripts\\python.exe' if os_name == 'nt' else './venv/bin/python'
+			inline_vars = ['`{env_python_path} -m devautotools env_with_vars_from_json {secret_files}`'.format(env_python_path=env_python_path, secret_files=' '.join([str(s) for s in secret_json_files_paths]))]
 		else:
 			inline_vars = []
 

--- a/devautotools/_django.py
+++ b/devautotools/_django.py
@@ -137,7 +137,14 @@ def django_settings_env_capture(**expected_sections):
 	:return:
 	:rtype:
 	"""
-
+	
+	known_variations = (
+		'_CONTENT',
+		'_content',
+		'_BASE64',
+		'_base64',
+	)
+	
 	required_expected_sections, optional_expected_sections = set(), set()
 	for expected_section in expected_sections:
 		if re_search(REQUIRED_SECTION_RE, expected_section) is None:
@@ -148,20 +155,38 @@ def django_settings_env_capture(**expected_sections):
 
 	for required_section in required_expected_sections:
 		for required_setting in expected_sections[required_section]:
-			required_setting_value = getenv(required_setting, '')
-			if len(required_setting_value):
-				environmental_settings[required_setting] = required_setting_value
+			required_setting_found = False
+			for known_variation in known_variations:
+				required_setting_variation = required_setting + known_variation
+				required_setting_value = getenv(required_setting_variation, '')
+				if len(required_setting_value):
+					environmental_settings[required_setting_variation] = required_setting_value
+					required_setting_found = True
 			else:
+				required_setting_value = getenv(required_setting, '')
+				if len(required_setting_value):
+					environmental_settings[required_setting] = required_setting_value
+					required_setting_found = True
+			if not required_setting_found:
 				missing_setting_from_env.append(required_setting)
 	if len(missing_setting_from_env):
 		raise RuntimeError(f'Missing required settings from env: {missing_setting_from_env}')
 
 	for optional_section in optional_expected_sections:
 		for optional_setting in expected_sections[optional_section]:
-			optional_setting_value = getenv(optional_setting, '')
-			if len(optional_setting_value):
-				environmental_settings[optional_setting] = optional_setting_value
+			optional_setting_found = False
+			for known_variation in known_variations:
+				optional_setting_variation = optional_setting + known_variation
+				optional_setting_value = getenv(optional_setting_variation, '')
+				if len(optional_setting_value):
+					environmental_settings[optional_setting_variation] = optional_setting_value
+					optional_setting_found = True
 			else:
+				optional_setting_value = getenv(optional_setting, '')
+				if len(optional_setting_value):
+					environmental_settings[optional_setting] = optional_setting_value
+					optional_setting_found = True
+			if not optional_setting_found:
 				missing_setting_from_env.append(optional_setting)
 	if len(missing_setting_from_env):
 		warn(f'Missing optional settings from env: {missing_setting_from_env}', RuntimeWarning)

--- a/devautotools/_env.py
+++ b/devautotools/_env.py
@@ -7,38 +7,53 @@ from base64 import b64decode, b64encode
 from configparser import ConfigParser
 from json import dumps as json_dumps, load as json_load, loads as json_loads
 from logging import getLogger
+from os import name as os_name
 from pathlib import Path
 from shlex import quote as shlex_quote
 
 LOGGER = getLogger(__name__)
 
-def env_vars_from_ini(*input_files, sep=' ', uppercase_vars=False):
+
+def _env_with_vars_from_file(*input_files, file_loader, sep=' ', uppercase_vars=False):
 	"""Env variables from INI files
 	Parses INI files containing the variables and prints a line, ready to be fed to "env".
 	"""
+	
+	variables = globals()[file_loader](*input_files)
+	if uppercase_vars:
+		variables = {key.upper(): value for key, value in variables.items()}
+	if os_name == 'nt':
+		variables = [f'$env:{key}={shlex_quote(str(value))};' for key, value in variables.items()]
+		return sep.join(variables)
+	else:
+		variables = [f'{key}={shlex_quote(str(value))}' for key, value in variables.items()]
+		return f'env {sep.join(variables)}'
 
+
+def _load_vars_from_ini(*input_files):
+	"""Load env vars from ini
+	Parses INI files containing the variables and returns a flat dictionary with them.
+	"""
+	
 	result = {}
-
+	
 	for input_file in input_files:
 		input_file = Path(input_file)
 		if input_file.is_file():
 			LOGGER.debug('Working with file: %s', input_file)
 		else:
 			LOGGER.error('Unable to access file: %s', input_file)
-
+		
 		config = ConfigParser()
 		config.optionxform = str
 		config.read_file(input_file.open())
 		for section, content in config.items():
 			LOGGER.debug('Adding settings from section %s', section)
-			for key, value in content.items():
-				if uppercase_vars:
-					key = key.upper()
-				result[key] = shlex_quote(str(value))
+			result.update(content)
+		return result
 
-	return sep.join(['='.join((key, value)) for key, value in result.items()])
 
-def env_vars_from_json(*input_files, sep=' ', uppercase_vars=False):
+def _load_vars_from_json(*input_files, sep=' ', uppercase_vars=False):
 	"""Env variables from JSON files
 	Parses JSON files containing the variables and prints a line, ready to be fed to "env".
 	"""
@@ -56,11 +71,9 @@ def env_vars_from_json(*input_files, sep=' ', uppercase_vars=False):
 		for key, value in content.items():
 			if isinstance(value, (list, dict)):
 				value = json_dumps(value)
-			if uppercase_vars:
-				key = key.upper()
-			result[key] = shlex_quote(str(value))
-
-	return sep.join(['='.join((key, value)) for key, value in result.items()])
+			result[key] = value
+			
+	return result
 
 
 def _pack_path(path_to_pack):
@@ -76,6 +89,7 @@ def _pack_path(path_to_pack):
 		raise ValueError('Not a packable path: {}'.format(path_to_pack))
 
 	return result
+
 
 def _unpack_path(tree_node, parent_path, overwrite_files = False):
 	"""Unpacks a path recursively
@@ -103,6 +117,18 @@ def _unpack_path(tree_node, parent_path, overwrite_files = False):
 			raise ValueError('Malformed path pack')
 
 	return result
+
+
+env_vars_from_ini = lambda *input_files, sep=' ', uppercase_vars=False: env_with_vars_from_ini(*input_files, sep=sep, uppercase_vars=uppercase_vars)[4:]
+
+
+env_vars_from_json = lambda *input_files, sep=' ', uppercase_vars=False: env_with_vars_from_json(*input_files, sep=sep, uppercase_vars=uppercase_vars)[4:]
+
+
+env_with_vars_from_ini = lambda *input_files, sep=' ', uppercase_vars=False: _env_with_vars_from_file(*input_files, '_load_vars_from_ini', sep=sep, uppercase_vars=uppercase_vars)
+
+
+env_with_vars_from_json = lambda *input_files, sep=' ', uppercase_vars=False: _env_with_vars_from_file(*input_files, '_load_vars_from_json', sep=sep, uppercase_vars=uppercase_vars)
 
 
 class EnvironmentalPipes:

--- a/devautotools/_env.py
+++ b/devautotools/_env.py
@@ -125,10 +125,10 @@ env_vars_from_ini = lambda *input_files, sep=' ', uppercase_vars=False: env_with
 env_vars_from_json = lambda *input_files, sep=' ', uppercase_vars=False: env_with_vars_from_json(*input_files, sep=sep, uppercase_vars=uppercase_vars)[4:]
 
 
-env_with_vars_from_ini = lambda *input_files, sep=' ', uppercase_vars=False: _env_with_vars_from_file(*input_files, '_load_vars_from_ini', sep=sep, uppercase_vars=uppercase_vars)
+env_with_vars_from_ini = lambda *input_files, sep=' ', uppercase_vars=False: _env_with_vars_from_file(*input_files, file_loader='_load_vars_from_ini', sep=sep, uppercase_vars=uppercase_vars)
 
 
-env_with_vars_from_json = lambda *input_files, sep=' ', uppercase_vars=False: _env_with_vars_from_file(*input_files, '_load_vars_from_json', sep=sep, uppercase_vars=uppercase_vars)
+env_with_vars_from_json = lambda *input_files, sep=' ', uppercase_vars=False: _env_with_vars_from_file(*input_files, file_loader='_load_vars_from_json', sep=sep, uppercase_vars=uppercase_vars)
 
 
 class EnvironmentalPipes:


### PR DESCRIPTION
- The setting search functionality was moved from `path_for_setting` into the new `decode_setting` function.
- Initial rework of the `env_vars_from_` function, creating the new `env_with_vars_from_` versions that are somewhat usable in Windows. (work in progress)
- Initial update of the `DjangoLinkedSite.deploy_locally` to account for Windows. (work in progress)